### PR TITLE
Don't segfault on `./sage --help`

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func main() {
 		}
 	}()
 	usageErr, err := handleErrors(&db)
-	if err != nil {
+	if err != nil && err != flag.ErrHelp {
 		fmt.Fprintln(os.Stderr, err)
 		if usageErr {
 			sync.Shutdown(db, 2)


### PR DESCRIPTION
Though harmless, this stops from printing the following after usage information
when a user runs `./sage --help`:

    [...]
    flag: help requested
    {"level":"info","msg":"Shutting down"}
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc0f8be]

    goroutine 1 [running]:
    github.com/johnstarich/sage/sync.Shutdown(0x0, 0x0, 0x2)
	    ./sage/sync/sync.go:12 +0x7e
    main.main()
	    ./sage/main.go:189 +0x12b